### PR TITLE
Use os.path.realpath before git log

### DIFF
--- a/yasfb/__init__.py
+++ b/yasfb/__init__.py
@@ -70,6 +70,9 @@ def _get_last_updated(app, pagename):
         # value to the entire site.
         src_file = app.builder.env.doc2path(pagename)
         if os.path.exists(src_file):
+            # Get the real path of any symlinks, otherwise git won't have
+            # a log and no last_update can be found.
+            src_file = os.path.realpath(src_file)
             try:
                 last_updated_t = subprocess.check_output(
                     [


### PR DESCRIPTION
git log doesn't produce output for symlinks. It's often the case that documentation is symlinks from elsewhere into sphinx's doc path. These files will not be included in the RSS feed because they will have no last update time as the result of having no git log.

The change turns any src path into a real path before calling git log.